### PR TITLE
Feature/conditional creation

### DIFF
--- a/output.tf
+++ b/output.tf
@@ -1,4 +1,4 @@
 output "s3_bucket_id" {
   description = "The ID of the s3 bucket"
-  value       = "${aws_s3_bucket.this.id}"
+  value       = "${join(" ", aws_s3_bucket.this.*.id)}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -36,3 +36,13 @@ variable "loggingBucket" {
   description = "The bucket you want to log S3 access to."
   default     = ""
 }
+
+variable "create_bucket" {
+  description = "Conditionally create S3 bucket"
+  default     = true
+}
+
+variable "upload_files" {
+  description = "Conditionally upload files"
+  default     = true
+}


### PR DESCRIPTION
Modules do not yet support `count` to be able to conditionally create them.

This means conditionally creating resources needs to be done within the module itself.

This PR allows passing the `create_bucket` and `upload_files` variables, to conditionally create a bucket, and to conditionally upload files to the specified bucket name.