### PR TITLE
(Feature) Allow enabling versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,13 @@ Example of Bucket with only private access
 
 ```hcl
 module "s3_bucket" {
-    source         = "Smartbrood/s3-bucket/aws"
-    s3_fqdn        = "${var.s3_fqdn}"
-    aws_account_id = "${var.aws_account_id}"
-    aws_username   = "${var.aws_username}"
-    files          = "${var.files}"
-    base64_files   = "${var.base64_files}"
+    source            = "Smartbrood/s3-bucket/aws"
+    s3_fqdn           = "${var.s3_fqdn}"
+    aws_account_id    = "${var.aws_account_id}"
+    aws_username      = "${var.aws_username}"
+    files             = "${var.files}"
+    base64_files      = "${var.base64_files}"
+    enable_versioning = "${var.enable_versioning}"
 
     tags = {
         Terraform   = "true"
@@ -30,12 +31,13 @@ Example of Bucket with read public access
 
 ```hcl
 module "s3_bucket" {
-    source         = "Smartbrood/s3-bucket/aws"
-    s3_fqdn        = "${var.s3_fqdn}"
-    aws_account_id = "${var.aws_account_id}"
-    aws_username   = "${var.aws_username}"
-    files          = "${var.files}"
-    base64_files   = "${var.base64_files}"
+    source            = "Smartbrood/s3-bucket/aws"
+    s3_fqdn           = "${var.s3_fqdn}"
+    aws_account_id    = "${var.aws_account_id}"
+    aws_username      = "${var.aws_username}"
+    files             = "${var.files}"
+    base64_files      = "${var.base64_files}"
+    enable_versioning = "${var.enable_versioning}"
 
     allow_public   = "true"
 

--- a/main.tf
+++ b/main.tf
@@ -22,6 +22,10 @@ resource "aws_s3_bucket" "this" {
     target_bucket = "${var.loggingBucket != "" ? var.loggingBucket : local.defaultLoggingBucket}"
     target_prefix = "log/"
   }
+
+  versioning {
+    enabled = "${var.enable_versioning}"
+  }
 }
 
 resource "aws_s3_bucket_policy" "private" {

--- a/variables.tf
+++ b/variables.tf
@@ -46,3 +46,8 @@ variable "upload_files" {
   description = "Conditionally upload files"
   default     = true
 }
+
+variable "enable_versioning" {
+  description = "Conditionally enable versioning"
+  default     = false
+}


### PR DESCRIPTION
* Adds the `enable_versioning` variable (default is false)
* Setting to true will turn on Versioning for the S3 bucket